### PR TITLE
Fix Scattered dragging, contrast, and keyboard controls

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 ISC License
 
-Copyright (c) 2026 Aubrey Alexander
+Copyright (c) 2018–2026 Aubrey Alexander
 
 Permission to use, copy, modify, and/or distribute this software for any
 purpose with or without fee is hereby granted, provided that the above

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Or load a JSON document declaratively:
 
 `select`, `change`, `load`, and `error` bubble and cross the shadow boundary. A `change` event contains the complete updated radar, the changed item, and its complete prior value.
 
-Focus a point, then use arrow keys to move it. Enter or Space selects it; Escape clears selection. Add `readonly` for a non-editable reporting view.
+Focus a point, then use arrow keys to move it. `W`/`A`/`S`/`D` offer the same spatial movement shortcut. Enter or Space selects it; Escape clears selection. Add `readonly` for a non-editable reporting view.
 
 ## Original-data compatibility
 
@@ -74,4 +74,4 @@ Scattered normalizes that document on load, preserving its slices, bands, and po
 
 ## License
 
-[ISC](LICENSE) © Aubrey Alexander
+[ISC](LICENSE) © 2018–2026 Aubrey Alexander

--- a/src/interactions.js
+++ b/src/interactions.js
@@ -11,7 +11,20 @@ export function placementFromPointer(event, svg, data, radius) {
 export function placementFromKey(item, key, data) {
   const sliceIndex = data.slices.findIndex(({ id }) => id === item.slice);
   const bandIndex = data.bands.findIndex(({ id }) => id === item.band);
-  if (key === 'ArrowRight' || key === 'ArrowLeft') return { ...item, slice: data.slices[(sliceIndex + (key === 'ArrowRight' ? 1 : -1) + data.slices.length) % data.slices.length].id };
-  if (key === 'ArrowUp' || key === 'ArrowDown') return { ...item, band: data.bands[Math.max(0, Math.min(data.bands.length - 1, bandIndex + (key === 'ArrowDown' ? 1 : -1)))].id };
+  const normalizedKey = key.toLowerCase();
+  const movesRight = key === 'ArrowRight' || normalizedKey === 'd';
+  const movesLeft = key === 'ArrowLeft' || normalizedKey === 'a';
+  const movesInward = key === 'ArrowUp' || normalizedKey === 'w';
+  const movesOutward = key === 'ArrowDown' || normalizedKey === 's';
+
+  if (movesRight || movesLeft) {
+    const direction = movesRight ? 1 : -1;
+    return { ...item, slice: data.slices[(sliceIndex + direction + data.slices.length) % data.slices.length].id };
+  }
+  if (movesInward || movesOutward) {
+    const direction = movesOutward ? 1 : -1;
+    const nextBand = Math.max(0, Math.min(data.bands.length - 1, bandIndex + direction));
+    return { ...item, band: data.bands[nextBand].id };
+  }
   return null;
 }

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -5,10 +5,10 @@ const VIEWBOX_SIZE = 760;
 const CHART_RADIUS = VIEWBOX_SIZE * 0.39;
 
 export const styles = `
-  :host { display: block; min-width: 0; }
+  :host { display: block; min-width: 0; user-select: none; -webkit-user-select: none; }
   svg { display: block; width: 100%; height: auto; overflow: visible; }
-  .ring, .spoke { fill: none; stroke: #dcd4ca; stroke-width: 1; stroke-dasharray: 2 5; }
-  .band-label { fill: #8d8279; font: 11px system-ui, sans-serif; text-anchor: middle; }
+  .ring, .spoke { fill: none; stroke: #81786f; stroke-width: 1.5; stroke-dasharray: 3 5; }
+  .band-label { fill: #625b54; font: 11px system-ui, sans-serif; text-anchor: middle; }
   .slice-label { font: 750 15px system-ui, sans-serif; text-anchor: middle; }
   .point { cursor: grab; stroke: #fff; stroke-width: 3; transition: r .15s ease; }
   .point:hover, .point:focus { r: 17; outline: none; }
@@ -69,7 +69,9 @@ function appendPoint(svg, item, number, data, selectedId, callbacks) {
   point.append(title);
 
   point.addEventListener('click', () => callbacks.onSelect(item));
-  point.addEventListener('focus', () => callbacks.onSelect(item));
+  // Pointer down gives an SVG point focus before the drag completes. Keep that
+  // focus update render-free so it cannot replace the active pointer target.
+  point.addEventListener('focus', () => callbacks.onFocus(item));
   point.addEventListener('pointerdown', (event) => callbacks.onPointerDown(item, point, event, CHART_RADIUS));
   point.addEventListener('keydown', (event) => callbacks.onKeyDown(item, event));
   svg.append(point);
@@ -80,7 +82,14 @@ function appendPoint(svg, item, number, data, selectedId, callbacks) {
 }
 
 /** Render the stateless SVG view used by the <scattered-radar> custom element. */
-export function renderRadar(data, { selectedId, filter, onSelect, onPointerDown, onKeyDown }) {
+export function renderRadar(data, {
+  selectedId,
+  filter,
+  onFocus,
+  onSelect,
+  onPointerDown,
+  onKeyDown,
+}) {
   const svg = svgElement('svg', {
     'aria-label': data.title || 'Interactive radar chart',
     role: 'img',
@@ -90,7 +99,7 @@ export function renderRadar(data, { selectedId, filter, onSelect, onPointerDown,
   appendBandGuides(svg, data.bands);
   appendSliceGuides(svg, data.slices);
 
-  const callbacks = { onSelect, onPointerDown, onKeyDown };
+  const callbacks = { onFocus, onSelect, onPointerDown, onKeyDown };
   const visibleItems = data.items.filter((item) => {
     const slice = data.slices.find(({ id }) => id === item.slice);
     const band = data.bands.find(({ id }) => id === item.band);

--- a/src/scattered-radar.js
+++ b/src/scattered-radar.js
@@ -71,6 +71,7 @@ export class ScatteredRadar extends HTMLElement {
     style.textContent = styles;
     const svg = renderRadar(this.#data, {
       filter: this.#filter,
+      onFocus: (item) => this.#select(item, { render: false }),
       onKeyDown: (item, event) => this.#moveWithKeys(item, event),
       onPointerDown: (...args) => this.#drag(...args),
       onSelect: (item) => this.#select(item),
@@ -79,10 +80,10 @@ export class ScatteredRadar extends HTMLElement {
     this.#root.replaceChildren(style, svg);
   }
 
-  #select(item) {
+  #select(item, { render = true } = {}) {
     this.#selectedId = item.id;
     this.dispatchEvent(radarEvent('select', { item: structuredClone(item) }));
-    this.render();
+    if (render) this.render();
   }
 
   #change(item, previous) {

--- a/tests/model.test.js
+++ b/tests/model.test.js
@@ -1,5 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { placementFromKey } from '../src/interactions.js';
 import { normalizeRadar, placementForPoint, validateRadar } from '../src/model.js';
 
 const data = { bands: [{ id: 'near', name: 'Near' }, { id: 'far', name: 'Far' }], slices: [{ id: 'east', name: 'East', color: '#123456' }, { id: 'west', name: 'West', color: '#abcdef' }], items: [{ id: 'one', name: 'One', band: 'near', slice: 'east' }] };
@@ -15,4 +16,23 @@ test('accepts the original radar document shape', () => {
   const radar = normalizeRadar({ radar: [{ name: 'One', points: [{ name: 'Item', band: 'near' }] }], bands: { near: { value: 1, name: 'Near' } } });
   assert.deepEqual(radar.items[0].band, 'near');
   assert.equal(radar.slices[0].name, 'One');
+});
+
+test('moves a focused item with arrow keys and wraps across slices', () => {
+  const item = data.items[0];
+  assert.equal(placementFromKey(item, 'ArrowRight', data).slice, 'west');
+  assert.equal(placementFromKey({ ...item, slice: 'west' }, 'ArrowRight', data).slice, 'east');
+  assert.equal(placementFromKey(item, 'ArrowLeft', data).slice, 'west');
+  assert.equal(placementFromKey(item, 'ArrowDown', data).band, 'far');
+  assert.equal(placementFromKey(item, 'ArrowUp', data).band, 'near');
+});
+
+test('supports WASD shortcuts and keeps movement inside the available bands', () => {
+  const item = data.items[0];
+  assert.equal(placementFromKey(item, 'd', data).slice, 'west');
+  assert.equal(placementFromKey(item, 'A', data).slice, 'west');
+  assert.equal(placementFromKey(item, 's', data).band, 'far');
+  assert.equal(placementFromKey(item, 'W', data).band, 'near');
+  assert.equal(placementFromKey({ ...item, band: 'far' }, 's', data).band, 'far');
+  assert.equal(placementFromKey(item, 'x', data), null);
 });


### PR DESCRIPTION
## Summary

- prevents focus from replacing the active pointer target during drag
- disables text selection in the chart and strengthens the radial guide contrast
- supports W/A/S/D alongside standard arrow-key navigation
- adds keyboard-navigation tests for both schemes, slice wrapping, and band boundaries
- restores the license history to © 2018–2026, based on the repository’s first commit on 2018-08-08

## Verification

- `npm test` (6 passing)
- `git diff --check`
- visually reviewed the clearer guide lines on the local demo